### PR TITLE
Document Nomad deployment

### DIFF
--- a/src/administration/install_nomad.md
+++ b/src/administration/install_nomad.md
@@ -1,0 +1,14 @@
+# Nomad Deployment (unsupported)
+
+Lemmy can be deployed onto a Nomad cluster, which has benefits including:
+- distributing services across several machines (you can have the DB on a machine and the backend running on a different one)
+- relocating load if a machine fails
+- potentially load-balancing across stateless services (like the UI) if desired
+- rolling updates for less downtime
+
+The downsides include:
+- requiring an existing Nomad cluster already deployed
+- extra configuration depending on your existing set-up
+- not officially supported
+
+You can see examples of job files that you can use as a starting point at the [Lemmy-Nomad](https://github.com/LemmyNet/lemmy-nomad) repo.


### PR DESCRIPTION
The existing guides in lemmy-docs only show hoow to deploy Lemmy to a single machine. While this makes the process simpler, deploying to an orchestrator (like Kubernetes or nomad) has
benefits, especially for the larger instances out there.

I have already deployed a personal Lemmy instance on a Nomad cluster at r.dcotta.eu and would love to document the process for whoever comes next. I have already made a repo with some examples 
[here](https://github.com/Cottand/lemmy-on-nomad-examples) but upstreaming that to this website would make it more visible. I think creating a repo `LemmyNet/lemmy-nomad` would be the way
to go in order to stay consistent, but we can also just link my repo here. I will let the maintainers decide.

I understand supporting another deployment method is painful, so I added 'Unsupported', for what that's worth.
